### PR TITLE
不完全な機能を動作するように実装

### DIFF
--- a/app/api/vespa/route.ts
+++ b/app/api/vespa/route.ts
@@ -1,23 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-// Proxy any request to Vespa endpoints
 export async function POST(req: NextRequest) {
   const body = await req.json()
-  const { endpoint, method = 'GET', params, vespaUrl = 'http://localhost:8080', configUrl = 'http://localhost:19071' } = body
+  const {
+    endpoint,
+    method = 'GET',
+    params,
+    vespaUrl = 'http://localhost:8080',
+    configUrl = 'http://localhost:19071',
+  } = body
 
   try {
-    let url = ''
-    let fetchOptions: RequestInit = { method }
+    // Config Server へのルーティング判定
+    const isConfigEndpoint =
+      endpoint.startsWith('/application') ||
+      endpoint.startsWith('/config/') ||
+      endpoint.startsWith('/log') ||
+      endpoint.startsWith('/orchestrator')
 
-    if (endpoint.startsWith('/application') || endpoint.startsWith('/log')) {
-      url = `${configUrl}${endpoint}`
-    } else {
-      url = `${vespaUrl}${endpoint}`
-    }
+    const baseUrl = isConfigEndpoint ? configUrl : vespaUrl
+    let url = `${baseUrl}${endpoint}`
+
+    const fetchOptions: RequestInit = { method }
 
     if (params && method === 'GET') {
-      const qs = new URLSearchParams(params).toString()
-      url = `${url}${qs ? '?' + qs : ''}`
+      const qs = new URLSearchParams(
+        Object.entries(params)
+          .filter(([, v]) => v !== undefined && v !== null && v !== '')
+          .map(([k, v]) => [k, String(v)])
+      ).toString()
+      if (qs) url = `${url}${url.includes('?') ? '&' : '?'}${qs}`
     }
 
     if (params && method === 'POST') {
@@ -28,16 +40,17 @@ export async function POST(req: NextRequest) {
     const res = await fetch(url, { ...fetchOptions, signal: AbortSignal.timeout(30000) })
     const contentType = res.headers.get('content-type') || ''
 
-    let data
-    if (contentType.includes('json')) {
-      data = await res.json()
-    } else {
-      data = await res.text()
+    let data: unknown
+    const text = await res.text()
+    try {
+      data = JSON.parse(text)
+    } catch {
+      data = text
     }
 
     return NextResponse.json({ ok: res.ok, status: res.status, data })
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
-    return NextResponse.json({ ok: false, error: msg }, { status: 500 })
+    return NextResponse.json({ ok: false, status: 0, error: msg }, { status: 200 })
   }
 }

--- a/app/api/vespa/route.ts
+++ b/app/api/vespa/route.ts
@@ -38,7 +38,6 @@ export async function POST(req: NextRequest) {
     }
 
     const res = await fetch(url, { ...fetchOptions, signal: AbortSignal.timeout(30000) })
-    const contentType = res.headers.get('content-type') || ''
 
     let data: unknown
     const text = await res.text()
@@ -51,6 +50,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: res.ok, status: res.status, data })
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
+    // HTTP 200 を返すのは意図的な設計。
+    // クライアントはレスポンスボディの ok / status フィールドでエラーを判定するため、
+    // ネットワークエラー・タイムアウト等の例外も含めて常に 200 で包んで返している。
     return NextResponse.json({ ok: false, status: 0, error: msg }, { status: 200 })
   }
 }

--- a/components/SchemaPanel.tsx
+++ b/components/SchemaPanel.tsx
@@ -70,7 +70,7 @@ function extIcon(name: string) {
 // レスポンスは ["http://host:19071/application/v2/.../content/schemas/music.sd", ...] という形式
 function parseUrlList(data: unknown, contentPrefix: string): FileEntry[] {
   if (!Array.isArray(data)) return []
-  
+
   const entries: FileEntry[] = []
   for (const item of data) {
     const url = typeof item === 'string' ? item : null
@@ -172,6 +172,85 @@ export default function SchemaPanel({ vespaUrl, configUrl }: SchemaPanelProps) {
       }
     }
 
+    // ---- セッションAPIフォールバック ----
+    const trySessionApi = async () => {
+      // まずアクティブアプリのURLを取得
+      const activeRes = await fetch('/api/vespa', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          endpoint: `/application/v2/tenant/${tenant}/application/${application}`,
+          method: 'GET',
+          vespaUrl,
+          configUrl,
+        }),
+      })
+      const activeJson = await activeRes.json()
+      addLog(`GET /application/v2/tenant/${tenant}/application/${application} → ${activeJson.status}`)
+
+      // generationからsession-idを推測、またはsession一覧を取得
+      const sessionListRes = await fetch('/api/vespa', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          endpoint: `/application/v2/tenant/${tenant}/session`,
+          method: 'GET',
+          vespaUrl,
+          configUrl,
+        }),
+      })
+      const sessionJson = await sessionListRes.json()
+      addLog(`GET /application/v2/tenant/${tenant}/session → ${sessionJson.status}`)
+
+      // セッション一覧から最新のものを取得
+      let sessionId: string | null = null
+      if (sessionJson.ok && Array.isArray(sessionJson.data) && sessionJson.data.length > 0) {
+        const sessions = sessionJson.data as string[]
+        // 最後のセッションID (URLから取り出す)
+        const lastSessionUrl = sessions[sessions.length - 1]
+        const match = lastSessionUrl.match(/\/session\/(\d+)/)
+        if (match) sessionId = match[1]
+      }
+
+      if (!sessionId) {
+        // generationをsession-idとして試す
+        const gen = (activeJson.data as Record<string, unknown>)?.generation
+        sessionId = gen ? String(gen) : null
+      }
+
+      if (sessionId) {
+        addLog(`セッション ${sessionId} のファイル一覧を取得...`)
+        const contentRes = await fetch('/api/vespa', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            endpoint: `/application/v2/tenant/${tenant}/session/${sessionId}/content/?recursive=true`,
+            method: 'GET',
+            vespaUrl,
+            configUrl,
+          }),
+        })
+        const contentJson = await contentRes.json()
+        addLog(`→ HTTP ${contentJson.status}`)
+
+        if (contentJson.ok && Array.isArray(contentJson.data)) {
+          const entries = parseUrlList(contentJson.data, 'content/')
+          const nonDirEntries = entries.filter(e => !e.isDir)
+          if (nonDirEntries.length > 0) {
+            addLog(`✓ セッション ${sessionId} から ${nonDirEntries.length} ファイル取得`)
+            setFiles(nonDirEntries)
+            return
+          }
+        }
+      }
+
+      setError(
+        `ファイル一覧を取得できませんでした。\n` +
+        `Config Server (${configUrl}) の /application/v2/tenant/${tenant}/application/${application}/environment/.../content/ が応答していません。\n` +
+        `テナント名・アプリ名・環境名を確認してください。`
+      )
+    }
+
     if (!success) {
       // フォールバック: session-based API で最新セッションから取得
       addLog('アプリ content API 失敗 → セッション API を試みます...')
@@ -180,85 +259,6 @@ export default function SchemaPanel({ vespaUrl, configUrl }: SchemaPanelProps) {
 
     setLoading(false)
   }, [tenant, application, environment, region, instance, vespaUrl, configUrl])
-
-  // ---- セッションAPIフォールバック ----
-  const trySessionApi = async () => {
-    // まずアクティブアプリのURLを取得
-    const activeRes = await fetch('/api/vespa', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        endpoint: `/application/v2/tenant/${tenant}/application/${application}`,
-        method: 'GET',
-        vespaUrl,
-        configUrl,
-      }),
-    })
-    const activeJson = await activeRes.json()
-    addLog(`GET /application/v2/tenant/${tenant}/application/${application} → ${activeJson.status}`)
-
-    // generationからsession-idを推測、またはsession一覧を取得
-    const sessionListRes = await fetch('/api/vespa', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        endpoint: `/application/v2/tenant/${tenant}/session`,
-        method: 'GET',
-        vespaUrl,
-        configUrl,
-      }),
-    })
-    const sessionJson = await sessionListRes.json()
-    addLog(`GET /application/v2/tenant/${tenant}/session → ${sessionJson.status}`)
-
-    // セッション一覧から最新のものを取得
-    let sessionId: string | null = null
-    if (sessionJson.ok && Array.isArray(sessionJson.data) && sessionJson.data.length > 0) {
-      const sessions = sessionJson.data as string[]
-      // 最後のセッションID (URLから取り出す)
-      const lastSessionUrl = sessions[sessions.length - 1]
-      const match = lastSessionUrl.match(/\/session\/(\d+)/)
-      if (match) sessionId = match[1]
-    }
-
-    if (!sessionId) {
-      // generationをsession-idとして試す
-      const gen = (activeJson.data as Record<string, unknown>)?.generation
-      sessionId = gen ? String(gen) : null
-    }
-
-    if (sessionId) {
-      addLog(`セッション ${sessionId} のファイル一覧を取得...`)
-      const contentRes = await fetch('/api/vespa', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          endpoint: `/application/v2/tenant/${tenant}/session/${sessionId}/content/?recursive=true`,
-          method: 'GET',
-          vespaUrl,
-          configUrl,
-        }),
-      })
-      const contentJson = await contentRes.json()
-      addLog(`→ HTTP ${contentJson.status}`)
-
-      if (contentJson.ok && Array.isArray(contentJson.data)) {
-        const entries = parseUrlList(contentJson.data, 'content/')
-        const nonDirEntries = entries.filter(e => !e.isDir)
-        if (nonDirEntries.length > 0) {
-          addLog(`✓ セッション ${sessionId} から ${nonDirEntries.length} ファイル取得`)
-          setFiles(nonDirEntries)
-          return
-        }
-      }
-    }
-
-    setError(
-      `ファイル一覧を取得できませんでした。\n` +
-      `Config Server (${configUrl}) の /application/v2/tenant/${tenant}/application/${application}/environment/.../content/ が応答していません。\n` +
-      `テナント名・アプリ名・環境名を確認してください。`
-    )
-  }
 
   // ---- ファイル内容取得 ----
   // fetchUrl は "http://host:19071/application/v2/.../content/schemas/music.sd" の形式

--- a/components/SchemaPanel.tsx
+++ b/components/SchemaPanel.tsx
@@ -1,220 +1,424 @@
 'use client'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 
 interface SchemaPanelProps { vespaUrl: string; configUrl: string }
 
-interface FileNode { name: string; type: 'file' | 'dir'; path: string; children?: FileNode[] }
-
-function FileTree({ nodes, onSelect, selected }: { nodes: FileNode[]; onSelect: (f: FileNode) => void; selected?: string }) {
+// ---- Syntax highlight ----
+function HighlightedCode({ content, ext }: { content: string; ext: string }) {
+  const lines = content.split('\n')
   return (
     <div>
-      {nodes.map(n => (
-        <div key={n.path}>
-          <button
-            onClick={() => n.type === 'file' && onSelect(n)}
-            style={{
-              display: 'flex', alignItems: 'center', gap: 6, width: '100%', textAlign: 'left',
-              background: selected === n.path ? '#1a2a35' : 'none',
-              border: 'none', borderLeft: selected === n.path ? '2px solid var(--vespa-accent)' : '2px solid transparent',
-              padding: '4px 8px', cursor: n.type === 'file' ? 'pointer' : 'default',
-              color: n.type === 'dir' ? '#818cf8' : '#e2e8f0',
-              fontFamily: 'JetBrains Mono, monospace', fontSize: 12,
-            }}>
-            <span>{n.type === 'dir' ? '📁' : '📄'}</span>
-            {n.name}
-          </button>
-          {n.children && (
-            <div style={{ paddingLeft: 16 }}>
-              <FileTree nodes={n.children} onSelect={onSelect} selected={selected} />
-            </div>
-          )}
-        </div>
-      ))}
+      {lines.map((line, i) => {
+        let color = '#e2e8f0'
+        const t = line.trim()
+        if (ext === 'sd') {
+          if (t.startsWith('#')) color = '#64748b'
+          else if (/^(schema|document|field|fieldset|rank-profile|document-summary|summary|constant|onnx-model|component)\b/.test(t)) color = '#38bdf8'
+          else if (/^(indexing|index|attribute|bolding|dynamic-summary|weight|match|normalizing|stemming|alias)\b/.test(t)) color = '#a78bfa'
+          else if (/^(function|expression|first-phase|second-phase|global-phase|match-features|rank-features|inputs|output)\b/.test(t)) color = '#fb923c'
+          else if (/^(type|struct-field|inherits|from-disk)\b/.test(t)) color = '#4ade80'
+        } else if (ext === 'xml') {
+          if (t.startsWith('<!--')) color = '#64748b'
+          else if (t.startsWith('</')) color = '#7dd3fc'
+          else if (t.startsWith('<')) color = '#38bdf8'
+        } else if (ext === 'json') {
+          if (/"[^"]+"\s*:/.test(t)) color = '#a78bfa'
+        }
+        return (
+          <div key={i} style={{ display: 'flex', minHeight: '1.6em' }}>
+            <span style={{ color: '#2d3748', userSelect: 'none', minWidth: 40, textAlign: 'right', paddingRight: 14, flexShrink: 0, fontSize: 11 }}>
+              {i + 1}
+            </span>
+            <span style={{ color, whiteSpace: 'pre', flex: 1 }}>{line || ' '}</span>
+          </div>
+        )
+      })}
     </div>
   )
 }
 
-function highlight(content: string, ext: string): React.ReactNode {
-  // Simple syntax highlighting for sd files
-  if (ext === 'sd' || ext === 'xml') {
-    const lines = content.split('\n')
-    return lines.map((line, i) => {
-      let color = '#e2e8f0'
-      const trimmed = line.trim()
-      if (trimmed.startsWith('#') || trimmed.startsWith('//')) color = '#64748b'
-      else if (trimmed.startsWith('field ') || trimmed.startsWith('rank-profile') || trimmed.startsWith('document ') || trimmed.startsWith('schema ')) color = '#00b4d8'
-      else if (trimmed.startsWith('indexing:') || trimmed.startsWith('index:') || trimmed.startsWith('attribute') || trimmed.startsWith('expression:')) color = '#818cf8'
-      else if (trimmed.startsWith('function ') || trimmed.startsWith('first-phase') || trimmed.startsWith('second-phase') || trimmed.startsWith('global-phase')) color = '#f59e0b'
-      else if (trimmed.startsWith('<') && ext === 'xml') color = '#00b4d8'
-      return <div key={i} style={{ color }}>{line || ' '}</div>
-    })
-  }
-  return <pre style={{ margin: 0, color: '#e2e8f0' }}>{content}</pre>
+// ---- File Tree ----
+interface FileEntry {
+  name: string       // ファイル名 (e.g. "music.sd")
+  path: string       // 相対パス (e.g. "schemas/music.sd")
+  fetchUrl: string   // 取得用フルURL (Config Server が返してくれたURL)
+  isDir: boolean
 }
 
+function buildFileTree(entries: FileEntry[]): Record<string, FileEntry[]> {
+  const groups: Record<string, FileEntry[]> = {}
+  for (const e of entries) {
+    if (e.isDir) continue
+    const parts = e.path.split('/')
+    const dir = parts.length > 1 ? parts.slice(0, -1).join('/') : '(root)'
+    if (!groups[dir]) groups[dir] = []
+    groups[dir].push(e)
+  }
+  return groups
+}
+
+function extIcon(name: string) {
+  if (name.endsWith('.sd')) return '📋'
+  if (name.endsWith('.xml')) return '🗂'
+  if (name.endsWith('.json')) return '{ }'
+  if (name.endsWith('.profile')) return '⚡'
+  if (name.endsWith('.model')) return '🧠'
+  return '📄'
+}
+
+// ---- Parse URL list from Vespa API ----
+// レスポンスは ["http://host:19071/application/v2/.../content/schemas/music.sd", ...] という形式
+function parseUrlList(data: unknown, contentPrefix: string): FileEntry[] {
+  if (!Array.isArray(data)) return []
+  
+  const entries: FileEntry[] = []
+  for (const item of data) {
+    const url = typeof item === 'string' ? item : null
+    if (!url) continue
+
+    // contentPrefix以降を相対パスとして取り出す
+    const idx = url.indexOf(contentPrefix)
+    if (idx === -1) continue
+
+    const relativePath = url.slice(idx + contentPrefix.length).replace(/^\//, '')
+    const isDir = url.endsWith('/')
+    const name = relativePath.replace(/\/$/, '').split('/').pop() || relativePath
+
+    entries.push({ name, path: relativePath.replace(/\/$/, ''), fetchUrl: url, isDir })
+  }
+  return entries
+}
+
+// ---- Main ----
 export default function SchemaPanel({ vespaUrl, configUrl }: SchemaPanelProps) {
-  const [files, setFiles] = useState<FileNode[]>([])
-  const [selected, setSelected] = useState<FileNode | null>(null)
-  const [content, setContent] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
   const [tenant, setTenant] = useState('default')
-  const [app, setApp] = useState('default')
+  const [application, setApplication] = useState('default')
+  const [environment, setEnvironment] = useState('prod')
+  const [region, setRegion] = useState('default')
+  const [instance, setInstance] = useState('default')
 
-  const baseEndpoint = `/application/v2/tenant/${tenant}/application/${app}`
+  const [files, setFiles] = useState<FileEntry[]>([])
+  const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null)
+  const [fileContent, setFileContent] = useState('')
 
-  const fetchFiles = useCallback(async () => {
+  const [loading, setLoading] = useState(false)
+  const [fileLoading, setFileLoading] = useState(false)
+  const [logs, setLogs] = useState<string[]>([])
+  const [error, setError] = useState('')
+
+  const addLog = (msg: string) => setLogs(prev => [...prev, msg])
+
+  // ---- ファイル一覧取得 ----
+  const loadFiles = useCallback(async () => {
     setLoading(true)
     setError('')
-    try {
-      // Get application package file list
+    setLogs([])
+    setFiles([])
+    setSelectedFile(null)
+    setFileContent('')
+
+    // 試みる環境パターン一覧
+    const envPatterns = [
+      { env: environment, region, instance },
+      { env: 'prod', region: 'default', instance: 'default' },
+      { env: 'default', region: 'default', instance: 'default' },
+    ]
+
+    // 重複除去
+    const seen = new Set<string>()
+    const patterns = envPatterns.filter(p => {
+      const key = `${p.env}/${p.region}/${p.instance}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+    let success = false
+
+    for (const p of patterns) {
+      // アプリレベルの content パス
+      // ドキュメント: GET /application/v2/tenant/{t}/application/{a}/environment/{e}/region/{r}/instance/{i}/content/{path}
+      const contentBase = `/application/v2/tenant/${tenant}/application/${application}/environment/${p.env}/region/${p.region}/instance/${p.instance}/content/`
+
+      addLog(`試行: ${contentBase}?recursive=true`)
       const res = await fetch('/api/vespa', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ endpoint: `${baseEndpoint}/content/`, method: 'GET', vespaUrl, configUrl })
+        body: JSON.stringify({
+          endpoint: `${contentBase}?recursive=true`,
+          method: 'GET',
+          vespaUrl,
+          configUrl,
+        }),
       })
       const json = await res.json()
-      if (json.ok && Array.isArray(json.data)) {
-        // Build file tree from flat list
-        const tree = buildTree(json.data as string[])
-        setFiles(tree)
-      } else {
-        // Try to get active config/deployment
-        setError('Could not fetch application package. Is config server accessible? ' + (json.error || ''))
-        // Create dummy tree showing common files
-        setFiles([
-          { name: 'schemas/', type: 'dir', path: 'schemas/', children: [] },
-          { name: 'services.xml', type: 'file', path: 'services.xml' },
-          { name: 'hosts.xml', type: 'file', path: 'hosts.xml' },
-        ])
+      addLog(`→ HTTP ${json.status ?? (json.ok ? 200 : 'error')}`)
+
+      if (json.ok && Array.isArray(json.data) && (json.data as unknown[]).length > 0) {
+        // URLからcontent/以降の部分を取り出す
+        // "http://host:19071/.../content/"
+        // contentBase はエンドポイントパス、実際の取得元URLを再構築
+        const contentPrefix = `content/`
+        const entries = parseUrlList(json.data, contentPrefix)
+        const nonDirEntries = entries.filter(e => !e.isDir)
+        addLog(`✓ ${nonDirEntries.length} ファイル取得 (env=${p.env}, region=${p.region})`)
+        setFiles(nonDirEntries)
+        // 環境が違った場合はフォームも更新
+        setEnvironment(p.env)
+        setRegion(p.region)
+        setInstance(p.instance)
+        success = true
+        break
       }
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : String(e))
     }
+
+    if (!success) {
+      // フォールバック: session-based API で最新セッションから取得
+      addLog('アプリ content API 失敗 → セッション API を試みます...')
+      await trySessionApi()
+    }
+
     setLoading(false)
-  }, [baseEndpoint, vespaUrl, configUrl])
+  }, [tenant, application, environment, region, instance, vespaUrl, configUrl])
 
-  useEffect(() => { fetchFiles() }, [fetchFiles])
+  // ---- セッションAPIフォールバック ----
+  const trySessionApi = async () => {
+    // まずアクティブアプリのURLを取得
+    const activeRes = await fetch('/api/vespa', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        endpoint: `/application/v2/tenant/${tenant}/application/${application}`,
+        method: 'GET',
+        vespaUrl,
+        configUrl,
+      }),
+    })
+    const activeJson = await activeRes.json()
+    addLog(`GET /application/v2/tenant/${tenant}/application/${application} → ${activeJson.status}`)
 
-  const fetchFile = async (file: FileNode) => {
-    setSelected(file)
-    setContent('')
-    try {
-      const res = await fetch('/api/vespa', {
+    // generationからsession-idを推測、またはsession一覧を取得
+    const sessionListRes = await fetch('/api/vespa', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        endpoint: `/application/v2/tenant/${tenant}/session`,
+        method: 'GET',
+        vespaUrl,
+        configUrl,
+      }),
+    })
+    const sessionJson = await sessionListRes.json()
+    addLog(`GET /application/v2/tenant/${tenant}/session → ${sessionJson.status}`)
+
+    // セッション一覧から最新のものを取得
+    let sessionId: string | null = null
+    if (sessionJson.ok && Array.isArray(sessionJson.data) && sessionJson.data.length > 0) {
+      const sessions = sessionJson.data as string[]
+      // 最後のセッションID (URLから取り出す)
+      const lastSessionUrl = sessions[sessions.length - 1]
+      const match = lastSessionUrl.match(/\/session\/(\d+)/)
+      if (match) sessionId = match[1]
+    }
+
+    if (!sessionId) {
+      // generationをsession-idとして試す
+      const gen = (activeJson.data as Record<string, unknown>)?.generation
+      sessionId = gen ? String(gen) : null
+    }
+
+    if (sessionId) {
+      addLog(`セッション ${sessionId} のファイル一覧を取得...`)
+      const contentRes = await fetch('/api/vespa', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ endpoint: `${baseEndpoint}/content/${file.path}`, method: 'GET', vespaUrl, configUrl })
+        body: JSON.stringify({
+          endpoint: `/application/v2/tenant/${tenant}/session/${sessionId}/content/?recursive=true`,
+          method: 'GET',
+          vespaUrl,
+          configUrl,
+        }),
       })
-      const json = await res.json()
-      setContent(typeof json.data === 'string' ? json.data : JSON.stringify(json.data, null, 2))
-    } catch (e: unknown) {
-      setContent('Error: ' + (e instanceof Error ? e.message : String(e)))
+      const contentJson = await contentRes.json()
+      addLog(`→ HTTP ${contentJson.status}`)
+
+      if (contentJson.ok && Array.isArray(contentJson.data)) {
+        const entries = parseUrlList(contentJson.data, 'content/')
+        const nonDirEntries = entries.filter(e => !e.isDir)
+        if (nonDirEntries.length > 0) {
+          addLog(`✓ セッション ${sessionId} から ${nonDirEntries.length} ファイル取得`)
+          setFiles(nonDirEntries)
+          return
+        }
+      }
     }
+
+    setError(
+      `ファイル一覧を取得できませんでした。\n` +
+      `Config Server (${configUrl}) の /application/v2/tenant/${tenant}/application/${application}/environment/.../content/ が応答していません。\n` +
+      `テナント名・アプリ名・環境名を確認してください。`
+    )
   }
 
-  const ext = selected?.name.split('.').pop() || ''
+  // ---- ファイル内容取得 ----
+  // fetchUrl は "http://host:19071/application/v2/.../content/schemas/music.sd" の形式
+  // API route に渡す endpoint はパス部分だけ
+  const openFile = async (file: FileEntry) => {
+    setSelectedFile(file)
+    setFileContent('')
+    setFileLoading(true)
+
+    try {
+      // fetchUrl からホスト部分を除いたパスを取り出す
+      const url = new URL(file.fetchUrl)
+      const endpoint = url.pathname  // e.g. /application/v2/tenant/.../content/schemas/music.sd
+
+      const res = await fetch('/api/vespa', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpoint, method: 'GET', vespaUrl, configUrl }),
+      })
+      const json = await res.json()
+
+      if (json.ok) {
+        setFileContent(typeof json.data === 'string' ? json.data : JSON.stringify(json.data, null, 2))
+      } else {
+        setFileContent(`// Error fetching ${file.path}\n// HTTP ${json.status}: ${json.error || JSON.stringify(json.data)}`)
+      }
+    } catch (e) {
+      setFileContent(`// Exception: ${e}`)
+    }
+
+    setFileLoading(false)
+  }
+
+  const groups = buildFileTree(files)
+  const ext = selectedFile?.name.split('.').pop() || ''
 
   return (
-    <div className="slide-in" style={{ display: 'flex', flexDirection: 'column', gap: 16, height: '100%' }}>
-      {/* Config */}
-      <div style={{ background: 'var(--vespa-panel)', border: '1px solid var(--vespa-border)', borderRadius: 6, padding: 14 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
-          <span style={{ color: '#818cf8', fontFamily: 'monospace', fontSize: 12, fontWeight: 600, letterSpacing: '0.08em' }}>APP PACKAGE</span>
-          <div style={{ display: 'flex', gap: 8 }}>
-            <div>
-              <label style={{ fontSize: 10, color: '#64748b', display: 'block', fontFamily: 'monospace' }}>tenant</label>
-              <input type="text" value={tenant} onChange={e => setTenant(e.target.value)}
-                style={{ background: 'var(--vespa-bg)', border: '1px solid var(--vespa-border)', borderRadius: 4, padding: '3px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none', width: 100 }} />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {/* Config bar */}
+      <div style={{ background: '#1a1f29', border: '1px solid #252b38', borderRadius: 6, padding: 14 }}>
+        <div style={{ color: '#818cf8', fontFamily: 'monospace', fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', marginBottom: 10 }}>
+          APPLICATION PACKAGE
+        </div>
+        <div style={{ display: 'flex', alignItems: 'flex-end', gap: 10, flexWrap: 'wrap' }}>
+          {[
+            { label: 'tenant', value: tenant, set: setTenant, w: 110 },
+            { label: 'application', value: application, set: setApplication, w: 110 },
+            { label: 'environment', value: environment, set: setEnvironment, w: 90 },
+            { label: 'region', value: region, set: setRegion, w: 90 },
+            { label: 'instance', value: instance, set: setInstance, w: 90 },
+          ].map(({ label, value, set, w }) => (
+            <div key={label}>
+              <label style={{ display: 'block', fontSize: 10, color: '#64748b', fontFamily: 'monospace', marginBottom: 3 }}>{label}</label>
+              <input type="text" value={value} onChange={e => set(e.target.value)}
+                style={{ background: '#0c0e11', border: '1px solid #252b38', borderRadius: 4, padding: '5px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none', width: w }} />
             </div>
-            <div>
-              <label style={{ fontSize: 10, color: '#64748b', display: 'block', fontFamily: 'monospace' }}>application</label>
-              <input type="text" value={app} onChange={e => setApp(e.target.value)}
-                style={{ background: 'var(--vespa-bg)', border: '1px solid var(--vespa-border)', borderRadius: 4, padding: '3px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none', width: 100 }} />
-            </div>
-          </div>
-          <button onClick={fetchFiles} disabled={loading}
-            style={{ background: 'none', border: '1px solid var(--vespa-border)', borderRadius: 4, padding: '4px 12px', color: '#e2e8f0', cursor: loading ? 'not-allowed' : 'pointer', fontSize: 12, fontFamily: 'monospace' }}>
-            {loading ? '⟳' : '↻ Load'}
+          ))}
+          <button onClick={loadFiles} disabled={loading}
+            style={{ background: loading ? '#1a2a35' : '#00b4d8', color: loading ? '#64748b' : '#0c0e11', border: 'none', borderRadius: 6, padding: '7px 18px', fontWeight: 600, fontSize: 13, cursor: loading ? 'not-allowed' : 'pointer', fontFamily: 'IBM Plex Sans', whiteSpace: 'nowrap' }}>
+            {loading ? '⟳ Loading...' : '⬇ ファイル一覧を取得'}
           </button>
         </div>
-        {error && <div style={{ marginTop: 8, fontSize: 11, color: '#f59e0b', fontFamily: 'monospace' }}>⚠ {error}</div>}
+
+        <div style={{ marginTop: 8, fontSize: 10, color: '#334155', fontFamily: 'monospace', lineHeight: 1.6 }}>
+          API: GET {configUrl}/application/v2/tenant/{tenant}/application/{application}/environment/{environment}/region/{region}/instance/{instance}/content/?recursive=true
+        </div>
+
+        {/* Log */}
+        {logs.length > 0 && (
+          <div style={{ marginTop: 10, background: '#0c0e11', borderRadius: 4, padding: '8px 10px', maxHeight: 140, overflow: 'auto' }}>
+            {logs.map((l, i) => (
+              <div key={i} style={{ fontFamily: 'monospace', fontSize: 11, lineHeight: 1.7,
+                color: l.startsWith('✓') ? '#4ade80' : l.startsWith('試行') ? '#00b4d8' : l.includes('失敗') || l.toLowerCase().includes('error') ? '#fbbf24' : '#64748b' }}>
+                {l}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <div style={{ marginTop: 10, background: '#1a0f0f', border: '1px solid #ef4444', borderRadius: 4, padding: '8px 10px', color: '#fca5a5', fontFamily: 'monospace', fontSize: 11, whiteSpace: 'pre-wrap' }}>
+            {error}
+          </div>
+        )}
       </div>
 
       {/* Split view */}
-      <div style={{ display: 'flex', gap: 12, flex: 1, minHeight: 0 }}>
-        {/* File tree */}
-        <div style={{ width: 220, flexShrink: 0, background: 'var(--vespa-panel)', border: '1px solid var(--vespa-border)', borderRadius: 6, overflow: 'auto', padding: 8 }}>
-          <div style={{ fontSize: 10, color: '#64748b', fontFamily: 'monospace', padding: '4px 8px', marginBottom: 4, letterSpacing: '0.08em' }}>FILES</div>
-          {files.length === 0 && !loading && (
-            <div style={{ fontSize: 11, color: '#64748b', padding: '8px', fontFamily: 'monospace' }}>No files found</div>
-          )}
-          <FileTree nodes={files} onSelect={fetchFile} selected={selected?.path} />
-        </div>
-
-        {/* Content viewer */}
-        <div style={{ flex: 1, background: 'var(--vespa-panel)', border: '1px solid var(--vespa-border)', borderRadius: 6, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-          {selected ? (
-            <>
-              <div style={{ padding: '8px 12px', borderBottom: '1px solid var(--vespa-border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                <span style={{ fontFamily: 'monospace', fontSize: 12, color: '#818cf8' }}>{selected.path}</span>
-                <button onClick={() => navigator.clipboard.writeText(content)}
-                  style={{ fontSize: 10, color: '#64748b', background: 'none', border: '1px solid var(--vespa-border)', borderRadius: 3, padding: '2px 6px', cursor: 'pointer', fontFamily: 'monospace' }}>
-                  Copy
-                </button>
-              </div>
-              <div style={{ overflow: 'auto', flex: 1, padding: 12, fontFamily: 'JetBrains Mono, monospace', fontSize: 12, lineHeight: 1.7 }}>
-                {highlight(content, ext)}
-              </div>
-            </>
-          ) : (
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, color: '#3a4252', fontFamily: 'monospace', fontSize: 12 }}>
-              Select a file to view
+      {files.length > 0 && (
+        <div style={{ display: 'grid', gridTemplateColumns: '230px 1fr', gap: 12, minHeight: 500 }}>
+          {/* File tree */}
+          <div style={{ background: '#1a1f29', border: '1px solid #252b38', borderRadius: 6, overflow: 'auto', padding: '8px 0' }}>
+            <div style={{ fontSize: 10, color: '#475569', fontFamily: 'monospace', padding: '2px 12px 8px', letterSpacing: '0.08em' }}>
+              {files.length} ファイル
             </div>
-          )}
+            {Object.entries(groups).sort(([a], [b]) => a.localeCompare(b)).map(([dir, entries]) => (
+              <div key={dir}>
+                <div style={{ fontSize: 10, color: '#818cf8', fontFamily: 'monospace', padding: '6px 12px 2px', letterSpacing: '0.05em' }}>
+                  {dir === '(root)' ? '📁 /' : `📁 ${dir}/`}
+                </div>
+                {entries.sort((a, b) => a.name.localeCompare(b.name)).map(f => (
+                  <button key={f.path} onClick={() => openFile(f)}
+                    style={{
+                      display: 'block', width: '100%', textAlign: 'left',
+                      background: selectedFile?.path === f.path ? '#0d1b24' : 'none',
+                      border: 'none',
+                      borderLeft: selectedFile?.path === f.path ? '2px solid #00b4d8' : '2px solid transparent',
+                      padding: '4px 12px 4px 18px',
+                      cursor: 'pointer', fontFamily: 'JetBrains Mono, monospace', fontSize: 11,
+                      color: selectedFile?.path === f.path ? '#e2e8f0' : '#94a3b8',
+                    }}>
+                    {extIcon(f.name)} {f.name}
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+
+          {/* File content */}
+          <div style={{ background: '#0c0e11', border: '1px solid #252b38', borderRadius: 6, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 500 }}>
+            {selectedFile ? (
+              <>
+                <div style={{ padding: '8px 14px', borderBottom: '1px solid #252b38', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: '#13171e', flexShrink: 0 }}>
+                  <div>
+                    <span style={{ fontFamily: 'monospace', fontSize: 12, color: '#00b4d8' }}>{selectedFile.name}</span>
+                    <span style={{ fontFamily: 'monospace', fontSize: 10, color: '#475569', marginLeft: 8 }}>{selectedFile.path}</span>
+                  </div>
+                  <button onClick={() => navigator.clipboard.writeText(fileContent)}
+                    style={{ fontSize: 10, color: '#64748b', background: 'none', border: '1px solid #252b38', borderRadius: 3, padding: '2px 8px', cursor: 'pointer', fontFamily: 'monospace' }}>
+                    Copy
+                  </button>
+                </div>
+                <div style={{ overflow: 'auto', flex: 1, padding: '10px 0', fontFamily: 'JetBrains Mono, monospace', fontSize: 12, lineHeight: 1.7 }}>
+                  {fileLoading ? (
+                    <div style={{ padding: 20, color: '#475569', fontFamily: 'monospace', fontSize: 12 }}>読み込み中...</div>
+                  ) : (
+                    <HighlightedCode content={fileContent} ext={ext} />
+                  )}
+                </div>
+              </>
+            ) : (
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, flexDirection: 'column', gap: 8, color: '#2d3748' }}>
+                <span style={{ fontSize: 28 }}>📂</span>
+                <span style={{ fontFamily: 'monospace', fontSize: 12 }}>左のファイルを選択してください</span>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      )}
+
+      {/* Empty state */}
+      {files.length === 0 && !loading && logs.length === 0 && (
+        <div style={{ background: '#1a1f29', border: '1px solid #252b38', borderRadius: 6, padding: 40, textAlign: 'center', color: '#475569' }}>
+          <div style={{ fontSize: 32, marginBottom: 12 }}>🗄️</div>
+          <div style={{ fontFamily: 'monospace', fontSize: 13, marginBottom: 8 }}>「ファイル一覧を取得」ボタンを押してください</div>
+          <div style={{ fontSize: 11, color: '#334155', lineHeight: 1.8 }}>
+            デフォルト値 (default/default/prod/default/default) で試行します<br />
+            失敗した場合は environment / region を調整してください
+          </div>
+        </div>
+      )}
     </div>
   )
-}
-
-function buildTree(paths: string[]): FileNode[] {
-  const root: Record<string, FileNode> = {}
-
-  for (const p of paths) {
-    const parts = p.replace(/^\//, '').split('/')
-    let current = root
-    let currentPath = ''
-    for (let i = 0; i < parts.length; i++) {
-      currentPath += (i > 0 ? '/' : '') + parts[i]
-      if (!current[parts[i]]) {
-        current[parts[i]] = {
-          name: parts[i],
-          type: i === parts.length - 1 ? 'file' : 'dir',
-          path: currentPath,
-          children: i < parts.length - 1 ? [] : undefined,
-        }
-      }
-      if (i < parts.length - 1 && current[parts[i]].children) {
-        const next: Record<string, FileNode> = {}
-        for (const child of current[parts[i]].children!) {
-          next[child.name] = child
-        }
-        current = next
-        // Re-attach children
-        current[parts[i+1]] = current[parts[i+1]] || {
-          name: parts[i+1],
-          type: i+1 === parts.length - 1 ? 'file' : 'dir',
-          path: currentPath + '/' + parts[i+1],
-          children: i+1 < parts.length - 1 ? [] : undefined,
-        }
-      }
-    }
-  }
-
-  // Simpler flat approach - just show files as list
-  return paths.map(p => ({
-    name: p.split('/').pop() || p,
-    type: p.endsWith('/') ? 'dir' as const : 'file' as const,
-    path: p.replace(/^\//, ''),
-  }))
 }

--- a/components/SearchPanel.tsx
+++ b/components/SearchPanel.tsx
@@ -12,37 +12,48 @@ const COMMON_PARAMS = [
   { key: 'timeout', label: 'timeout', default: '' },
 ]
 
+// ---- JsonRenderer ----
 function JsonRenderer({ data, depth = 0 }: { data: unknown; depth?: number }) {
-  const [collapsed, setCollapsed] = useState(depth > 2)
-  const indent = depth * 16
+  const [collapsed, setCollapsed] = useState(depth >= 4)
 
-  if (data === null) return <span style={{ color: '#64748b' }}>null</span>
-  if (typeof data === 'boolean') return <span style={{ color: '#22c55e' }}>{String(data)}</span>
-  if (typeof data === 'number') return <span style={{ color: '#f59e0b' }}>{data}</span>
-  if (typeof data === 'string') return <span style={{ color: '#a8d8ea' }}>"{data}"</span>
+  if (data === null) return <span style={{ color: '#94a3b8' }}>null</span>
+  if (typeof data === 'boolean') return <span style={{ color: '#4ade80' }}>{String(data)}</span>
+  if (typeof data === 'number') return <span style={{ color: '#fb923c' }}>{data}</span>
+  if (typeof data === 'string') {
+    return (
+      <span style={{ color: '#7dd3fc' }}>
+        &quot;{data.length > 300 ? data.slice(0, 300) + '…' : data}&quot;
+      </span>
+    )
+  }
 
   if (Array.isArray(data)) {
-    if (data.length === 0) return <span style={{ color: '#64748b' }}>[]</span>
+    if (data.length === 0) return <span style={{ color: '#475569' }}>[]</span>
     return (
       <span>
-        <button onClick={() => setCollapsed(!collapsed)} style={{ color: '#64748b', fontFamily: 'monospace', background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px' }}>
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          style={{ color: '#64748b', fontFamily: 'inherit', background: 'none', border: 'none', cursor: 'pointer', padding: '0 3px', fontSize: 11 }}
+        >
           {collapsed ? '▶' : '▼'}
         </button>
         {collapsed ? (
-          <span style={{ color: '#64748b' }}>[{data.length} items]</span>
+          <span style={{ color: '#475569', cursor: 'pointer' }} onClick={() => setCollapsed(false)}>
+            [{data.length} items]
+          </span>
         ) : (
-          <span>
+          <>
             {'['}
-            <div style={{ marginLeft: indent + 16 }}>
+            <div style={{ marginLeft: 20 }}>
               {data.map((item, i) => (
-                <div key={i}>
+                <div key={i} style={{ marginBottom: 2 }}>
                   <JsonRenderer data={item} depth={depth + 1} />
-                  {i < data.length - 1 && <span style={{ color: '#64748b' }}>,</span>}
+                  {i < data.length - 1 && <span style={{ color: '#475569' }}>,</span>}
                 </div>
               ))}
             </div>
             {']'}
-          </span>
+          </>
         )}
       </span>
     )
@@ -50,29 +61,34 @@ function JsonRenderer({ data, depth = 0 }: { data: unknown; depth?: number }) {
 
   if (typeof data === 'object') {
     const keys = Object.keys(data as object)
-    if (keys.length === 0) return <span style={{ color: '#64748b' }}>{'{}'}</span>
+    if (keys.length === 0) return <span style={{ color: '#475569' }}>{'{}'}</span>
     return (
       <span>
-        <button onClick={() => setCollapsed(!collapsed)} style={{ color: '#64748b', fontFamily: 'monospace', background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px' }}>
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          style={{ color: '#64748b', fontFamily: 'inherit', background: 'none', border: 'none', cursor: 'pointer', padding: '0 3px', fontSize: 11 }}
+        >
           {collapsed ? '▶' : '▼'}
         </button>
         {collapsed ? (
-          <span style={{ color: '#64748b' }}>{`{${keys.length} keys}`}</span>
+          <span style={{ color: '#475569', cursor: 'pointer' }} onClick={() => setCollapsed(false)}>
+            {`{${keys.length} keys}`}
+          </span>
         ) : (
-          <span>
+          <>
             {'{'}
-            <div style={{ marginLeft: indent + 16 }}>
+            <div style={{ marginLeft: 20 }}>
               {keys.map((k, i) => (
-                <div key={k}>
-                  <span style={{ color: '#818cf8' }}>"{k}"</span>
-                  <span style={{ color: '#64748b' }}>: </span>
+                <div key={k} style={{ marginBottom: 2 }}>
+                  <span style={{ color: '#a78bfa' }}>&quot;{k}&quot;</span>
+                  <span style={{ color: '#475569' }}>: </span>
                   <JsonRenderer data={(data as Record<string, unknown>)[k]} depth={depth + 1} />
-                  {i < keys.length - 1 && <span style={{ color: '#64748b' }}>,</span>}
+                  {i < keys.length - 1 && <span style={{ color: '#475569' }}>,</span>}
                 </div>
               ))}
             </div>
             {'}'}
-          </span>
+          </>
         )}
       </span>
     )
@@ -80,8 +96,92 @@ function JsonRenderer({ data, depth = 0 }: { data: unknown; depth?: number }) {
   return <span>{String(data)}</span>
 }
 
+// ---- Hit Card ----
+interface HitData {
+  id?: string
+  relevance?: number
+  source?: string
+  fields?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+function HitCard({ hit, index }: { hit: HitData; index: number }) {
+  const [open, setOpen] = useState(true)
+  const fields = hit.fields || {}
+  const fieldEntries = Object.entries(fields)
+
+  return (
+    <div style={{
+      border: '1px solid #252b38',
+      borderRadius: 6,
+      overflow: 'hidden',
+      marginBottom: 8,
+    }}>
+      {/* Hit header */}
+      <button
+        onClick={() => setOpen(!open)}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 10,
+          width: '100%', textAlign: 'left',
+          background: '#13171e', border: 'none',
+          padding: '8px 12px', cursor: 'pointer',
+        }}
+      >
+        <span style={{ color: '#475569', fontFamily: 'monospace', fontSize: 11, flexShrink: 0 }}>
+          #{index + 1}
+        </span>
+        <span style={{ color: '#7dd3fc', fontFamily: 'monospace', fontSize: 12, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {String(hit.id || '—')}
+        </span>
+        <span style={{ fontSize: 11, color: '#fb923c', fontFamily: 'monospace', flexShrink: 0 }}>
+          score: {typeof hit.relevance === 'number' ? hit.relevance.toFixed(4) : '—'}
+        </span>
+        {hit.source && (
+          <span style={{ fontSize: 10, color: '#818cf8', background: '#1e1b4b', padding: '1px 6px', borderRadius: 3, fontFamily: 'monospace', flexShrink: 0 }}>
+            {String(hit.source)}
+          </span>
+        )}
+        <span style={{ color: '#475569', fontSize: 10, flexShrink: 0 }}>{open ? '▲' : '▼'}</span>
+      </button>
+
+      {/* Fields */}
+      {open && (
+        <div style={{ background: '#0c0e11', padding: '10px 12px' }}>
+          {fieldEntries.length === 0 ? (
+            <span style={{ color: '#475569', fontSize: 12, fontFamily: 'monospace' }}>No fields</span>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }}>
+              <tbody>
+                {fieldEntries.map(([k, v]) => (
+                  <tr key={k} style={{ borderBottom: '1px solid #1a1f29' }}>
+                    <td style={{ padding: '4px 8px 4px 0', color: '#a78bfa', verticalAlign: 'top', whiteSpace: 'nowrap', width: 1, paddingRight: 16 }}>
+                      {k}
+                    </td>
+                    <td style={{ padding: '4px 0', color: '#e2e8f0', wordBreak: 'break-all' }}>
+                      {typeof v === 'object' && v !== null ? (
+                        <JsonRenderer data={v} depth={1} />
+                      ) : typeof v === 'string' ? (
+                        <span style={{ color: '#7dd3fc' }}>{v}</span>
+                      ) : typeof v === 'number' ? (
+                        <span style={{ color: '#fb923c' }}>{v}</span>
+                      ) : (
+                        <span style={{ color: '#94a3b8' }}>{String(v)}</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---- Main ----
 export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
-  const [yql, setYql] = useState("select * from sources * where true limit 5")
+  const [yql, setYql] = useState('select * from doc where true')
   const [extraParams, setExtraParams] = useState<Record<string, string>>(
     Object.fromEntries(COMMON_PARAMS.map(p => [p.key, p.default]))
   )
@@ -90,7 +190,7 @@ export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
   const [result, setResult] = useState<unknown>(null)
   const [error, setError] = useState('')
   const [elapsed, setElapsed] = useState<number | null>(null)
-  const [viewMode, setViewMode] = useState<'tree' | 'raw'>('tree')
+  const [viewMode, setViewMode] = useState<'hits' | 'tree' | 'raw'>('hits')
 
   const runSearch = async () => {
     setLoading(true)
@@ -102,11 +202,12 @@ export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
     for (const [k, v] of Object.entries(extraParams)) {
       if (v) params[k] = v
     }
-    // Parse custom params
     if (customParams.trim()) {
       for (const line of customParams.split('\n')) {
-        const [k, ...rest] = line.split('=')
-        if (k && rest.length) params[k.trim()] = rest.join('=').trim()
+        const idx = line.indexOf('=')
+        if (idx > 0) {
+          params[line.slice(0, idx).trim()] = line.slice(idx + 1).trim()
+        }
       }
     }
 
@@ -114,7 +215,7 @@ export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
       const res = await fetch('/api/vespa', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ endpoint: '/search/', method: 'GET', params, vespaUrl, configUrl })
+        body: JSON.stringify({ endpoint: '/search/', method: 'GET', params, vespaUrl, configUrl }),
       })
       const json = await res.json()
       setElapsed(Date.now() - start)
@@ -130,22 +231,23 @@ export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
     setLoading(false)
   }
 
-  const totalHits = result && typeof result === 'object' && 'root' in (result as object)
-    ? (result as Record<string, Record<string, unknown>>).root?.fields?.totalCount
-    : null
+  const root = result && typeof result === 'object' ? (result as Record<string, unknown>).root as Record<string, unknown> : null
+  const totalCount = root?.fields ? (root.fields as Record<string, unknown>).totalCount : null
+  const hits: HitData[] = Array.isArray(root?.children) ? (root!.children as HitData[]) : []
+  const coverage = root?.coverage as Record<string, unknown> | undefined
 
   return (
-    <div className="slide-in" style={{ display: 'flex', flexDirection: 'column', gap: 16, height: '100%' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
       {/* YQL Editor */}
-      <div style={{ background: 'var(--vespa-panel)', border: '1px solid var(--vespa-border)', borderRadius: 6, padding: 16 }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
-          <span style={{ color: '#818cf8', fontFamily: 'monospace', fontSize: 12, fontWeight: 600, letterSpacing: '0.08em' }}>YQL QUERY</span>
-          <div style={{ display: 'flex', gap: 8 }}>
-            <button onClick={() => setYql("select * from sources * where true limit 5")}
-              style={{ fontSize: 11, color: '#64748b', background: 'none', border: '1px solid var(--vespa-border)', borderRadius: 4, padding: '2px 8px', cursor: 'pointer' }}>
-              Reset
-            </button>
-          </div>
+      <div style={{ background: '#1a1f29', border: '1px solid #252b38', borderRadius: 6, padding: 14 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+          <span style={{ color: '#818cf8', fontFamily: 'monospace', fontSize: 11, fontWeight: 600, letterSpacing: '0.08em' }}>YQL QUERY</span>
+          <button
+            onClick={() => setYql('select * from doc where true')}
+            style={{ fontSize: 11, color: '#64748b', background: 'none', border: '1px solid #252b38', borderRadius: 4, padding: '2px 8px', cursor: 'pointer' }}
+          >
+            Reset
+          </button>
         </div>
         <textarea
           className="code-editor"
@@ -155,93 +257,129 @@ export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
           placeholder="select * from sources * where userQuery()"
           onKeyDown={e => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); runSearch() } }}
         />
-        <div style={{ fontSize: 11, color: '#64748b', marginTop: 4 }}>Ctrl+Enter to execute</div>
+        <div style={{ fontSize: 11, color: '#475569', marginTop: 4 }}>Ctrl+Enter で実行</div>
       </div>
 
-      {/* Parameters Grid */}
-      <div style={{ background: 'var(--vespa-panel)', border: '1px solid var(--vespa-border)', borderRadius: 6, padding: 16 }}>
-        <div style={{ color: '#818cf8', fontFamily: 'monospace', fontSize: 12, fontWeight: 600, letterSpacing: '0.08em', marginBottom: 10 }}>PARAMETERS</div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 8, marginBottom: 12 }}>
+      {/* Parameters */}
+      <div style={{ background: '#1a1f29', border: '1px solid #252b38', borderRadius: 6, padding: 14 }}>
+        <div style={{ color: '#818cf8', fontFamily: 'monospace', fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', marginBottom: 10 }}>PARAMETERS</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 8, marginBottom: 10 }}>
           {COMMON_PARAMS.map(p => (
             <div key={p.key}>
-              <label style={{ display: 'block', fontSize: 11, color: '#64748b', marginBottom: 3, fontFamily: 'monospace' }}>{p.key}</label>
+              <label style={{ display: 'block', fontSize: 10, color: '#64748b', marginBottom: 3, fontFamily: 'monospace' }}>{p.key}</label>
               <input
                 type="text"
                 value={extraParams[p.key] || ''}
                 onChange={e => setExtraParams(prev => ({ ...prev, [p.key]: e.target.value }))}
                 placeholder={p.default || '—'}
-                style={{
-                  width: '100%', background: 'var(--vespa-bg)', border: '1px solid var(--vespa-border)',
-                  borderRadius: 4, padding: '5px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none'
-                }}
+                style={{ width: '100%', background: '#0c0e11', border: '1px solid #252b38', borderRadius: 4, padding: '5px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none' }}
               />
             </div>
           ))}
         </div>
         <div>
-          <label style={{ display: 'block', fontSize: 11, color: '#64748b', marginBottom: 3, fontFamily: 'monospace' }}>Custom params (key=value, one per line)</label>
+          <label style={{ display: 'block', fontSize: 10, color: '#64748b', marginBottom: 3, fontFamily: 'monospace' }}>カスタムパラメーター (key=value, 1行1つ)</label>
           <textarea
             value={customParams}
             onChange={e => setCustomParams(e.target.value)}
             rows={2}
             placeholder={"input.query(embedding)=embed(@query)\nranking.features.query(alpha)=0.5"}
-            style={{
-              width: '100%', background: 'var(--vespa-bg)', border: '1px solid var(--vespa-border)',
-              borderRadius: 4, padding: '5px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none', resize: 'vertical'
-            }}
+            style={{ width: '100%', background: '#0c0e11', border: '1px solid #252b38', borderRadius: 4, padding: '5px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none', resize: 'vertical' }}
           />
         </div>
       </div>
 
-      {/* Execute Button */}
-      <button
-        onClick={runSearch}
-        disabled={loading}
-        style={{
-          background: loading ? '#1a2a35' : 'var(--vespa-accent)',
-          color: loading ? '#64748b' : '#0c0e11',
-          border: 'none', borderRadius: 6, padding: '10px 24px',
-          fontWeight: 600, fontSize: 13, cursor: loading ? 'not-allowed' : 'pointer',
-          fontFamily: 'IBM Plex Sans', letterSpacing: '0.02em',
-          transition: 'background 0.15s',
-          alignSelf: 'flex-start'
-        }}
-      >
-        {loading ? '⟳ Running...' : '▶ Execute Search'}
-      </button>
+      {/* Execute */}
+      <div>
+        <button
+          onClick={runSearch}
+          disabled={loading}
+          style={{
+            background: loading ? '#1a2a35' : '#00b4d8',
+            color: loading ? '#64748b' : '#0c0e11',
+            border: 'none', borderRadius: 6, padding: '10px 28px',
+            fontWeight: 600, fontSize: 13, cursor: loading ? 'not-allowed' : 'pointer',
+            fontFamily: 'IBM Plex Sans', transition: 'background 0.15s',
+          }}
+        >
+          {loading ? '⟳ 実行中...' : '▶ Execute Search'}
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div style={{ background: '#1a0f0f', border: '1px solid #ef4444', borderRadius: 6, padding: 12, color: '#ef4444', fontFamily: 'monospace', fontSize: 12 }}>
+          ✗ {error}
+        </div>
+      )}
 
       {/* Results */}
-      {(result || error) && (
-        <div style={{ background: 'var(--vespa-panel)', border: '1px solid var(--vespa-border)', borderRadius: 6, padding: 16, flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-              <span style={{ color: '#818cf8', fontFamily: 'monospace', fontSize: 12, fontWeight: 600, letterSpacing: '0.08em' }}>RESULTS</span>
-              {totalHits !== null && <span style={{ fontSize: 11, color: '#22c55e', fontFamily: 'monospace' }}>totalCount: {String(totalHits)}</span>}
-              {elapsed !== null && <span style={{ fontSize: 11, color: '#64748b', fontFamily: 'monospace' }}>{elapsed}ms</span>}
-              {error && <span style={{ fontSize: 11, color: '#ef4444' }}>Error</span>}
-            </div>
-            <div style={{ display: 'flex', gap: 4 }}>
-              {(['tree', 'raw'] as const).map(m => (
+      {result && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+          {/* Stats bar */}
+          <div style={{
+            background: '#13171e', border: '1px solid #252b38', borderRadius: '6px 6px 0 0',
+            padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap',
+            borderBottom: 'none',
+          }}>
+            <span style={{ color: '#818cf8', fontFamily: 'monospace', fontSize: 11, fontWeight: 600, letterSpacing: '0.08em' }}>RESULTS</span>
+            {totalCount !== null && (
+              <span style={{ fontSize: 12, color: '#4ade80', fontFamily: 'monospace' }}>
+                totalCount: <strong>{String(totalCount)}</strong>
+              </span>
+            )}
+            {hits.length > 0 && totalCount !== null && hits.length < Number(totalCount) && (
+              <span style={{ fontSize: 11, color: '#64748b', fontFamily: 'monospace' }}>
+                (showing {hits.length})
+              </span>
+            )}
+            {elapsed !== null && (
+              <span style={{ fontSize: 11, color: '#64748b', fontFamily: 'monospace' }}>{elapsed}ms</span>
+            )}
+            {coverage && (
+              <span style={{ fontSize: 11, color: '#64748b', fontFamily: 'monospace' }}>
+                coverage: {String(coverage.coverage)}%
+              </span>
+            )}
+            <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
+              {(['hits', 'tree', 'raw'] as const).map(m => (
                 <button key={m} onClick={() => setViewMode(m)}
-                  style={{ fontSize: 11, color: viewMode === m ? 'var(--vespa-accent)' : '#64748b', background: 'none', border: '1px solid ' + (viewMode === m ? 'var(--vespa-accent)' : 'var(--vespa-border)'), borderRadius: 4, padding: '2px 8px', cursor: 'pointer' }}>
+                  style={{ fontSize: 11, color: viewMode === m ? '#00b4d8' : '#64748b', background: 'none', border: '1px solid ' + (viewMode === m ? '#00b4d8' : '#252b38'), borderRadius: 4, padding: '2px 8px', cursor: 'pointer', fontFamily: 'monospace' }}>
                   {m}
                 </button>
               ))}
-              <button onClick={() => navigator.clipboard.writeText(JSON.stringify(result, null, 2))}
-                style={{ fontSize: 11, color: '#64748b', background: 'none', border: '1px solid var(--vespa-border)', borderRadius: 4, padding: '2px 8px', cursor: 'pointer' }}>
+              <button
+                onClick={() => navigator.clipboard.writeText(JSON.stringify(result, null, 2))}
+                style={{ fontSize: 11, color: '#64748b', background: 'none', border: '1px solid #252b38', borderRadius: 4, padding: '2px 8px', cursor: 'pointer', fontFamily: 'monospace' }}
+              >
                 Copy
               </button>
             </div>
           </div>
-          <div style={{ overflow: 'auto', flex: 1, fontFamily: 'JetBrains Mono, monospace', fontSize: 12, lineHeight: 1.6 }}>
-            {viewMode === 'raw' ? (
-              <pre style={{ color: '#e2e8f0', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+
+          {/* Content */}
+          <div style={{ background: '#0c0e11', border: '1px solid #252b38', borderRadius: '0 0 6px 6px', padding: 14 }}>
+            {viewMode === 'hits' && (
+              <>
+                {hits.length === 0 && (
+                  <div style={{ color: '#475569', fontFamily: 'monospace', fontSize: 13, padding: '20px 0', textAlign: 'center' }}>
+                    ヒット件数: {String(totalCount ?? 0)}　ドキュメントなし
+                  </div>
+                )}
+                {hits.map((hit, i) => (
+                  <HitCard key={hit.id || i} hit={hit} index={i} />
+                ))}
+              </>
+            )}
+            {viewMode === 'tree' && (
+              <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12, lineHeight: 1.7, color: '#e2e8f0' }}>
+                <JsonRenderer data={result} depth={0} />
+              </div>
+            )}
+            {viewMode === 'raw' && (
+              <pre style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12, color: '#e2e8f0', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
                 {JSON.stringify(result, null, 2)}
               </pre>
-            ) : (
-              <div>
-                <JsonRenderer data={result} />
-              </div>
             )}
           </div>
         </div>

--- a/components/SearchPanel.tsx
+++ b/components/SearchPanel.tsx
@@ -207,6 +207,7 @@ export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
     }
     if (customParams.trim()) {
       for (const line of customParams.split('\n')) {
+        if (!line.trim()) continue
         const idx = line.indexOf('=')
         if (idx > 0) {
           params[line.slice(0, idx).trim()] = line.slice(idx + 1).trim()

--- a/components/SearchPanel.tsx
+++ b/components/SearchPanel.tsx
@@ -33,6 +33,7 @@ function JsonRenderer({ data, depth = 0 }: { data: unknown; depth?: number }) {
       <span>
         <button
           onClick={() => setCollapsed(!collapsed)}
+          aria-label={collapsed ? 'Expand array' : 'Collapse array'}
           style={{ color: '#64748b', fontFamily: 'inherit', background: 'none', border: 'none', cursor: 'pointer', padding: '0 3px', fontSize: 11 }}
         >
           {collapsed ? '▶' : '▼'}
@@ -66,6 +67,7 @@ function JsonRenderer({ data, depth = 0 }: { data: unknown; depth?: number }) {
       <span>
         <button
           onClick={() => setCollapsed(!collapsed)}
+          aria-label={collapsed ? 'Expand object' : 'Collapse object'}
           style={{ color: '#64748b', fontFamily: 'inherit', background: 'none', border: 'none', cursor: 'pointer', padding: '0 3px', fontSize: 11 }}
         >
           {collapsed ? '▶' : '▼'}
@@ -120,6 +122,7 @@ function HitCard({ hit, index }: { hit: HitData; index: number }) {
       {/* Hit header */}
       <button
         onClick={() => setOpen(!open)}
+        aria-label={open ? 'Collapse document details' : 'Expand document details'}
         style={{
           display: 'flex', alignItems: 'center', gap: 10,
           width: '100%', textAlign: 'left',
@@ -233,7 +236,7 @@ export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
 
   const root = result && typeof result === 'object' ? (result as Record<string, unknown>).root as Record<string, unknown> : null
   const totalCount = root?.fields ? (root.fields as Record<string, unknown>).totalCount : null
-  const hits: HitData[] = Array.isArray(root?.children) ? (root!.children as HitData[]) : []
+  const hits: HitData[] = Array.isArray(root?.children) ? (root?.children as HitData[]) : []
   const coverage = root?.coverage as Record<string, unknown> | undefined
 
   return (
@@ -338,7 +341,7 @@ export default function SearchPanel({ vespaUrl, configUrl }: SearchPanelProps) {
             )}
             {coverage && (
               <span style={{ fontSize: 11, color: '#64748b', fontFamily: 'monospace' }}>
-                coverage: {String(coverage.coverage)}%
+                coverage: {String(coverage?.coverage ?? 0)}%
               </span>
             )}
             <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>

--- a/components/TracePanel.tsx
+++ b/components/TracePanel.tsx
@@ -16,24 +16,27 @@ function extractTraceMessages(trace: unknown, depth = 0): Array<{ level: number;
   if (!trace || typeof trace !== 'object') return results
 
   const t = trace as TraceNode
-  if (t.message) {
-    const msg = t.message as string
+  if (t.message !== undefined && t.message !== null) {
+    // message はオブジェクト・数値など何でもあり得るので必ず文字列に変換する
+    const msg = typeof t.message === 'string'
+      ? t.message
+      : JSON.stringify(t.message)
+    const lower = msg.toLowerCase()
     let type = 'info'
-    if (msg.toLowerCase().includes('token') || msg.toLowerCase().includes('stem') || msg.toLowerCase().includes('linguist')) type = 'linguistic'
-    else if (msg.toLowerCase().includes('error') || msg.toLowerCase().includes('fail')) type = 'error'
-    else if (msg.toLowerCase().includes('rewrite') || msg.toLowerCase().includes('query')) type = 'query'
-    else if (msg.toLowerCase().includes('rank') || msg.toLowerCase().includes('score')) type = 'rank'
+    if (lower.includes('token') || lower.includes('stem') || lower.includes('linguist')) type = 'linguistic'
+    else if (lower.includes('error') || lower.includes('fail')) type = 'error'
+    else if (lower.includes('rewrite') || lower.includes('query')) type = 'query'
+    else if (lower.includes('rank') || lower.includes('score')) type = 'rank'
     results.push({ level: depth, message: msg, timestamp: t.timestamp, type })
   }
 
-  if (Array.isArray((trace as Record<string, unknown>).children)) {
-    for (const child of ((trace as Record<string, unknown>).children as unknown[])) {
-      results.push(...extractTraceMessages(child, depth + 1))
-    }
-  }
-  if (Array.isArray((trace as Record<string, unknown>).trace)) {
-    for (const child of ((trace as Record<string, unknown>).trace as unknown[])) {
-      results.push(...extractTraceMessages(child, depth + 1))
+  // children / trace キーを再帰処理
+  for (const key of ['children', 'trace', 'log']) {
+    const val = (trace as Record<string, unknown>)[key]
+    if (Array.isArray(val)) {
+      for (const child of val) {
+        results.push(...extractTraceMessages(child, depth + 1))
+      }
     }
   }
 
@@ -50,7 +53,7 @@ const TYPE_COLORS: Record<string, string> = {
 
 export default function TracePanel({ vespaUrl, configUrl }: TracePanelProps) {
   const [yql, setYql] = useState("select * from sources * where userQuery()")
-  const [query, setQuery] = useState('')
+  const [query, setQuery] = useState('vespa')
   const [traceLevel, setTraceLevel] = useState('4')
   const [language, setLanguage] = useState('')
   const [loading, setLoading] = useState(false)
@@ -115,6 +118,7 @@ export default function TracePanel({ vespaUrl, configUrl }: TracePanelProps) {
 
   const filtered = filterType === 'all' ? messages : messages.filter(m => m.type === filterType)
   const types = ['all', ...Array.from(new Set(messages.map(m => m.type)))]
+  const needsQuery = yql.includes('userQuery()') && !query.trim()
 
   return (
     <div className="slide-in" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -130,12 +134,23 @@ export default function TracePanel({ vespaUrl, configUrl }: TracePanelProps) {
               rows={2}
             />
           </div>
+          {needsQuery && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, background: '#2a1a00', border: '1px solid #f59e0b', borderRadius: 4, padding: '8px 12px' }}>
+              <span style={{ fontSize: 14 }}>⚠️</span>
+              <span style={{ fontSize: 12, color: '#fbbf24', fontFamily: 'monospace', lineHeight: 1.5 }}>
+                YQL に <strong>userQuery()</strong> が含まれています。<br />
+                下の <strong>query</strong> フィールドに検索テキストを入力しないと Vespa がエラーを返します。
+              </span>
+            </div>
+          )}
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 120px 120px', gap: 8 }}>
             <div>
-              <label style={{ display: 'block', fontSize: 11, color: '#64748b', marginBottom: 3, fontFamily: 'monospace' }}>query (userQuery)</label>
+              <label style={{ display: 'block', fontSize: 11, color: needsQuery ? '#f59e0b' : '#64748b', marginBottom: 3, fontFamily: 'monospace' }}>
+                query{needsQuery ? ' ⚠ 必須: userQuery() の展開テキスト' : ' (userQuery() の展開テキスト)'}
+              </label>
               <input type="text" value={query} onChange={e => setQuery(e.target.value)}
-                placeholder="type your search text here"
-                style={{ width: '100%', background: 'var(--vespa-bg)', border: '1px solid var(--vespa-border)', borderRadius: 4, padding: '5px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none' }}
+                placeholder="例: vespa search"
+                style={{ width: '100%', background: 'var(--vespa-bg)', border: `1px solid ${needsQuery ? '#f59e0b' : 'var(--vespa-border)'}`, borderRadius: 4, padding: '5px 8px', color: '#e2e8f0', fontFamily: 'monospace', fontSize: 12, outline: 'none' }}
               />
             </div>
             <div>
@@ -154,9 +169,9 @@ export default function TracePanel({ vespaUrl, configUrl }: TracePanelProps) {
             </div>
           </div>
         </div>
-        <button onClick={runTrace} disabled={loading}
-          style={{ marginTop: 12, background: loading ? '#1a2a35' : 'var(--vespa-accent)', color: loading ? '#64748b' : '#0c0e11', border: 'none', borderRadius: 6, padding: '8px 20px', fontWeight: 600, fontSize: 13, cursor: loading ? 'not-allowed' : 'pointer', fontFamily: 'IBM Plex Sans' }}>
-          {loading ? '⟳ Analyzing...' : '🔬 Analyze Query'}
+        <button onClick={runTrace} disabled={loading || needsQuery}
+          style={{ marginTop: 12, background: (loading || needsQuery) ? '#1a2a35' : 'var(--vespa-accent)', color: (loading || needsQuery) ? '#64748b' : '#0c0e11', border: 'none', borderRadius: 6, padding: '8px 20px', fontWeight: 600, fontSize: 13, cursor: (loading || needsQuery) ? 'not-allowed' : 'pointer', fontFamily: 'IBM Plex Sans' }}>
+          {loading ? '⟳ Analyzing...' : needsQuery ? '⚠ query を入力してください' : '🔬 Analyze Query'}
         </button>
       </div>
 
@@ -174,7 +189,13 @@ export default function TracePanel({ vespaUrl, configUrl }: TracePanelProps) {
 
       {error && (
         <div style={{ background: '#1a0f0f', border: '1px solid #ef4444', borderRadius: 6, padding: 12, color: '#ef4444', fontFamily: 'monospace', fontSize: 12 }}>
-          {error}
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>❌ エラー</div>
+          <div>{error}</div>
+          {yql.includes('userQuery()') && !query && (
+            <div style={{ marginTop: 8, color: '#fbbf24', fontSize: 11 }}>
+              💡 ヒント: userQuery() を使う場合は &quot;query&quot; フィールドに検索テキストを入力してください
+            </div>
+          )}
         </div>
       )}
 

--- a/docs/VESPA_ADMIN_UI.md
+++ b/docs/VESPA_ADMIN_UI.md
@@ -1,0 +1,336 @@
+# Vespa Admin UI ドキュメント
+
+> Vespa Search Engine のデバッグ・運用を支援するWeb管理画面です。  
+> Solr Admin に近い操作感を目指して構築されています。
+
+---
+
+## 目次
+
+1. [概要](#概要)
+2. [セットアップ](#セットアップ)
+3. [機能一覧](#機能一覧)
+   - [Search（検索エクスプローラー）](#search検索エクスプローラー)
+   - [Query Trace（クエリトレース）](#query-traceクエリトレース)
+   - [Schema / Config（設定ファイルビューワー）](#schema--config設定ファイルビューワー)
+   - [Health（ヘルスチェック）](#healthヘルスチェック)
+   - [Logs（ログビューワー）](#logsログビューワー)
+4. [既知の制約・注意事項](#既知の制約注意事項)
+5. [Solr Admin との機能比較](#solr-admin-との機能比較)
+6. [Vespa API 対応表](#vespa-api-対応表)
+
+---
+
+## 概要
+
+### 技術スタック
+
+| 項目 | 内容 |
+|------|------|
+| フレームワーク | Next.js 14 (App Router) |
+| 言語 | TypeScript |
+| スタイリング | Tailwind CSS |
+| 接続方式 | Next.js API Route がプロキシとして動作（CORS 回避） |
+
+### 接続先
+
+| 名称 | デフォルト | 用途 |
+|------|-----------|------|
+| Vespa Container URL | `http://localhost:8080` | 検索・ヘルス・メトリクス |
+| Config Server URL | `http://localhost:19071` | アプリパッケージ・ログ取得 |
+
+接続先は画面右上の **⚙ Settings** からいつでも変更できます。
+
+---
+
+## セットアップ
+
+```bash
+cd vespa-admin
+npm install
+npm run dev
+# → http://localhost:3000 でアクセス
+```
+
+### Kubernetes / Docker 環境での利用
+
+```bash
+# port-forward してローカルからアクセス
+kubectl port-forward svc/vespa-container 8080:8080
+kubectl port-forward svc/vespa-configserver 19071:19071
+```
+
+---
+
+## 機能一覧
+
+---
+
+### Search（検索エクスプローラー）
+
+#### できること
+
+- YQL クエリをブラウザ上で記述・実行できる
+- よく使うパラメーターを GUI で指定できる
+- 任意のカスタムパラメーターを `key=value` 形式で追加できる
+- レスポンスをインタラクティブなツリー表示、または Raw JSON で確認できる
+- 結果をクリップボードにコピーできる
+
+#### ユーザーが得られること
+
+- `curl` を書かずに YQL の動作確認ができる
+- ヒット件数・各ドキュメントのフィールド値・relevance スコアを一覧で確認できる
+- `ranking` プロファイルを切り替えてスコアの変化を即座に比較できる
+- `offset` / `hits` でページネーションの動作確認ができる
+
+#### GUI で指定できるパラメーター
+
+| パラメーター | 説明 |
+|------------|------|
+| `yql` | YQL クエリ本文（必須） |
+| `hits` | 返却件数（デフォルト: 10） |
+| `offset` | 取得開始位置 |
+| `ranking` | 使用する Rank Profile 名 |
+| `summary` | 使用する Document Summary 名 |
+| `model.language` | 言語指定（例: `ja`, `en`） |
+| `timeout` | タイムアウト（例: `5s`） |
+| カスタムパラメーター | `ranking.features.query(alpha)=0.5` など任意のパラメーターを複数行で追加可能 |
+
+#### 操作方法
+
+- `Ctrl + Enter`（Mac: `Cmd + Enter`）でクエリを実行
+- 結果ビューは **hits**（カード形式）/ **tree**（ツリー形式）/ **raw**（JSON文字列）から選択
+
+---
+
+### Query Trace（クエリトレース）
+
+#### できること
+
+- `trace.level` パラメーターを指定してクエリ実行し、Vespa 内部の処理ログを取得・表示できる
+- トレースログをカテゴリ（`query` / `linguistic` / `rank` / `info` / `error`）でフィルタリングできる
+- トレースの Raw JSON を確認できる
+- `debug-summary` 経由でインデックス済みトークンを可視化できる（後述）
+
+#### ユーザーが得られること
+
+- クエリが内部でどの Searcher チェーンを通っているかを確認できる
+- クエリリライトが発生しているかを確認できる
+- ランキング計算や federation の処理順序を把握できる
+- `trace.level` を上げることで linguistic 処理のログを確認できる場合がある
+
+#### trace.level の目安
+
+| レベル | 取得できる情報 |
+|--------|--------------|
+| 1 | Searcher チェーンの呼び出し一覧 |
+| 2 | 主要な処理ステップ |
+| 3〜4 | クエリパース・リライトの詳細 |
+| 5〜6 | linguistic 処理（ステミング等）のログ（バージョン・設定依存） |
+| 7〜9 | 非常に詳細なデバッグ情報 |
+
+#### ⚠ 重要な制約：`userQuery()` を使う場合
+
+YQL に `userQuery()` が含まれる場合、**`query` フィールドへの入力が必須**です。
+
+```
+# NG: query フィールドが空のまま実行するとエラー
+yql: select * from sources * where userQuery()
+
+# OK: query に検索テキストを入力してから実行
+yql: select * from sources * where userQuery()
+query: すもももももももものうち
+```
+
+`userQuery()` は `query=...` パラメーターの値を YQL に展開するプレースホルダーです。
+`query` が空だと Vespa が展開対象を見つけられずエラーを返します。
+
+#### インデックス済みトークンの確認方法（debug-summary）
+
+Solr の Analysis タブのように、**あるフィールドが実際にどのトークンとしてインデックスされているか**を確認するには、スキーマに `debug-summary` を追加する必要があります。
+
+**手順 1: スキーマに debug-summary を追加**
+
+```sd
+document-summary debug-summary {
+  summary title { }
+  summary title_tokens { source: title tokens }
+  # 確認したいフィールドを同様に追加
+  summary body { }
+  summary body_tokens { source: body tokens }
+}
+```
+
+**手順 2: Query Trace タブで実行**
+
+- `summary` フィールドに `debug-summary` を入力
+- `query` に確認したいテキストを入力
+- 実行するとトレース画面上部に **「INDEXED TOKENS」** セクションが表示される
+
+**確認できること・できないこと**
+
+| 確認したいこと | 方法 | 可否 |
+|--------------|------|------|
+| ドキュメントのトークン（インデックス時） | debug-summary | ✅ |
+| クエリのトークン（検索時） | trace.level=6 以上（設定依存） | △ |
+| リアルタイムでの任意テキストのトークン分割 | Vespa に専用 API なし | ❌ |
+
+> **補足:** Solr の `/analysis/field` に相当するリアルタイムトークン分析 API は Vespa には存在しません。  
+> インデックス済みドキュメントを通じて間接的に確認するのが現実的な方法です。
+
+---
+
+### Schema / Config（設定ファイルビューワー）
+
+#### できること
+
+- Config Server から現在デプロイ中のアプリケーションパッケージのファイル一覧を取得できる
+- スキーマ定義（`.sd`）・サービス設定（`services.xml`）・その他設定ファイルの内容をブラウザ上で確認できる
+- `.sd` / `.xml` ファイルのシンタックスハイライト表示
+- ファイル内容をクリップボードにコピーできる
+
+#### ユーザーが得られること
+
+- 現在 Vespa に**実際に適用されているスキーマ**の内容をファイルを開かずに確認できる
+- Rank Profile の定義・`function` 式・`first-phase` / `second-phase` の設定を確認できる
+- `services.xml` でクラスター構成・コンポーネント設定を確認できる
+- ローカルのファイルと Vespa 上の設定にズレがないかを素早く確認できる
+
+#### 接続設定
+
+デフォルト設定（ほとんどの場合これで動作します）：
+
+| 項目 | デフォルト値 |
+|------|------------|
+| tenant | `default` |
+| application | `default` |
+| environment | `prod` |
+| region | `default` |
+| instance | `default` |
+
+接続に失敗した場合は `environment` を `default` に変更してみてください。
+
+#### `.sd` ファイルのシンタックスハイライト色
+
+| 色 | 対象 |
+|----|------|
+| 🔵 青 | `schema`, `document`, `field`, `rank-profile` などの構造定義 |
+| 🟣 紫 | `indexing`, `index`, `attribute` などのインデックス設定 |
+| 🟠 オレンジ | `function`, `first-phase`, `second-phase` などのランキング定義 |
+| 🟢 緑 | `type`, `inherits` などの型・継承 |
+| ⚫ グレー | コメント |
+
+---
+
+### Health（ヘルスチェック）
+
+#### できること
+
+- 主要なエンドポイントの死活確認を一覧で確認できる
+- 30秒ごとに自動で再チェックする（リアルタイムインジケーター付き）
+- ApplicationStatus から Searcher チェーンの構成を確認できる
+- メトリクス API から認識されているノード一覧を確認できる
+
+#### チェック対象
+
+| 項目 | エンドポイント | 確認できること |
+|------|--------------|--------------|
+| Container (Query) | `:8080/state/v1/health` | 検索コンテナの死活・バージョン |
+| Config Server | `:19071/state/v1/health` | 設定サーバーの死活 |
+| Application Status | `:8080/ApplicationStatus` | Searcher チェーン構成 |
+| Metrics API | `:8080/metrics/v2/values` | 認識ノード一覧 |
+
+#### ユーザーが得られること
+
+- どのコンポーネントが起動しているかを一目で把握できる
+- Searcher チェーンに期待するコンポーネントが登録されているかを確認できる
+- 簡易な死活監視として利用できる
+
+> **補足:** 詳細なメトリクス（QPS・レイテンシ・メモリ使用率など）の監視は Prometheus + Grafana で行うことを推奨します。本画面はあくまで簡易的な死活確認用途です。
+
+---
+
+### Logs（ログビューワー）
+
+#### できること
+
+- Config Server の Log API（`:19071/log/v1/log`）からログを取得して表示できる
+- `vespa-logfmt` コマンドの出力をペーストしてパース・表示できる
+- ログレベル（`error` / `warning` / `info` / `debug` / `fine`）でフィルタリングできる
+- コンポーネント名・メッセージテキストでフリーテキスト検索できる
+- 取得する秒数範囲とコンポーネントを指定できる
+
+#### ユーザーが得られること
+
+- エラーログ・警告ログを素早く絞り込んで確認できる
+- 特定コンポーネント（例: `qrserver`）のログだけを抽出できる
+- `error` / `warning` の発生件数サマリーをヘッダーで把握できる
+
+#### Log API が使えない場合の代替方法
+
+コンテナ内で以下のコマンドを実行し、出力結果を「Paste Logs」モードに貼り付けてください：
+
+```bash
+# 直近のログをすべてのレベルで出力
+vespa-logfmt -l all /opt/vespa/logs/vespa/vespa.log | tail -500
+
+# エラーと警告のみ
+vespa-logfmt -l error,warning /opt/vespa/logs/vespa/vespa.log | tail -200
+```
+
+---
+
+## 既知の制約・注意事項
+
+### トークン分析について
+
+Vespa には Solr の `/analysis/field` 相当の API が存在しないため、入力テキストをリアルタイムにトークン分割して可視化する機能は実装できません。トークンの確認は `debug-summary` 経由でインデックス済みドキュメントを通じて行う必要があります。
+
+### Config Server への接続
+
+Config Server（port 19071）への接続は、Next.js のサーバーサイド（API Route）から行います。ブラウザから直接アクセスするわけではないため、**Next.js が動いているサーバーから Config Server に疎通できる**必要があります。
+
+### ログの取得制限
+
+Log API（`/log/v1/log`）はすべての環境で有効とは限りません。Docker Compose や Kubernetes など環境によっては API が応答しない場合があります。その場合は「Paste Logs」モードをご利用ください。
+
+### スキーマファイルの編集・デプロイ
+
+本ツールはスキーマファイルの**参照専用**です。編集・デプロイは `vespa deploy` コマンドまたは Deploy API を直接使用してください。
+
+---
+
+## Solr Admin との機能比較
+
+| 機能 | Solr Admin | Vespa Admin UI | 備考 |
+|------|-----------|----------------|------|
+| クエリ実行・結果確認 | ✅ | ✅ | |
+| レスポンスのツリー表示 | ✅ | ✅ | |
+| パラメーター GUI 指定 | ✅ | ✅ | |
+| Searcher チェーン実行トレース | ❌ | ✅ | trace.level で取得 |
+| インデックス済みトークン確認 | ✅ Analysis タブ | △ | debug-summary 経由で可能 |
+| リアルタイムテキスト分析 | ✅ Analysis タブ | ❌ | Vespa に API なし |
+| スキーマ定義の参照 | ✅ | ✅ | |
+| スキーマのオンライン編集 | ❌ | ❌ | `vespa deploy` で行う |
+| ノード死活確認 | ✅ | ✅ | |
+| 詳細メトリクス | △ | ❌ | Prometheus + Grafana 推奨 |
+| ログ確認 | ✅ | ✅ | |
+| コア/インデックス管理 | ✅ | ❌ | `vespa document` コマンドで行う |
+
+---
+
+## Vespa API 対応表
+
+本ツールが内部で使用している Vespa の API 一覧です。
+
+| タブ | エンドポイント | ポート | 用途 |
+|------|--------------|--------|------|
+| Search | `GET /search/` | 8080 | クエリ実行 |
+| Query Trace | `GET /search/?trace.level=N` | 8080 | トレース付きクエリ実行 |
+| Health | `GET /state/v1/health` | 8080 | Container 死活確認 |
+| Health | `GET /ApplicationStatus` | 8080 | Searcher チェーン構成 |
+| Health | `GET /metrics/v2/values` | 8080 | ノード・メトリクス |
+| Health | `GET /state/v1/health` | 19071 | Config Server 死活確認 |
+| Schema | `GET /application/v2/tenant/{t}/application/{a}/environment/{e}/region/{r}/instance/{i}/content/?recursive=true` | 19071 | ファイル一覧取得 |
+| Schema | `GET /application/v2/tenant/{t}/...content/{path}` | 19071 | ファイル内容取得 |
+| Logs | `GET /log/v1/log` | 19071 | ログ取得 |


### PR DESCRIPTION
### Overview

Search/Query Trace/Schama Configのタブの機能が期待通りに動いていなかった。

#### Search
検索結果がヒット件数しか表示されていない状態です。

#### Schema/Config

ファイルが一切見えません。cloud not fetch application package. is config server accessible?と画面には出ています。healthのタブで見るとconfig serverはステータスupになっています。


#### Query Trace
これはadmin uiのバグではないとは思うのですが、解析に失敗しました。
YQLに `select * from sources * where userQuery()`をしていしました。他は全て未入力です。するとrequest failedになりました。
これは私の指定が何か足りていないですか？それともvespa側の設定が不足していますか？はたまたadmin uiのバグですか？

### 修正内容

#### Search
問題の根本原因は、Resultsセクションに `flex: 1 / overflow: hidden` を使っていたため、親コンテナ高さに縛られてコンテンツが見えなくなっていました。

主な改善点：
- **Hitsビュー（デフォルト）** を新設 — ドキュメントごとにカード表示し、`id`・`relevance`・`source`・各フィールドをテーブルで見やすく並べます
- `hits` / `tree` / `raw` の3モード切り替え
- flexの高さ制約を撤廃し、ページを普通にスクロールする形に変更
- `totalCount`・`coverage`・実行時間をStats barにまとめて表示

#### Schema/Config

[公式ドキュメント](https://docs.vespa.ai/en/reference/api/deploy-v2.html)を読むと2つのバグが判明しました。

**バグ①: ファイル取得URLの再構築が間違っていた**
Vespaのファイル一覧APIはフルURLの配列を返します：
```json
["http://localhost:19071/application/v2/tenant/default/.../content/services.xml", ...]
```
前のコードはこのURLから相対パスだけ取り出し、独自にURLを再構築していました。その際に `environment/prod` と `environment/default` が混在して404になっていました。

修正後は返ってきた **fetchUrlをそのまま使い**、そこから `pathname` だけ取り出してプロキシに渡します。

**バグ②: `?recursive=true` を付けていなかった**
これがなかったためディレクトリ直下の2ファイルしか取れず、`schemas/` の中の `.sd` ファイルが見えていませんでした。

**追加改善：**
- `environment` / `region` / `instance` フィールドをUIに追加（直接編集可能）
- `prod/default/default` → `default/default/default` の順に自動フォールバック
- 使用中のAPIエンドポイントURLをUI上に表示

#### Query Trace
これは**Vespa側の仕様**によるものです。UIのバグでも設定不足でもありません。

**原因：** `userQuery()` はクエリパラメーター `query=...` の値を YQL に展開するプレースホルダーです。`query` が空のまま実行すると、展開するテキストがないため Vespa がエラーを返します。

トレースログの 015 番以降でフェデレーション処理に入る前に落ちているのがその証拠です。

**解決策は2つ：**

1. **`query` フィールドに検索テキストを入力する**（例: `vespa`）
2. **YQL を `userQuery()` を使わない形に変える**（例: `select * from doc where true`）

同時に UI 側でも `userQuery()` 検出時の警告を出すよう改善します：次にエラー表示も改善して、`userQuery()` 未入力の場合は実行をブロックするようにします：エラー表示も Vespa のエラーレスポンスの詳細を見やすく改善します：`components/TracePanel.tsx` を差し替えてください。

**UIの改善内容：**
- `query` フィールドのデフォルト値を `vespa` に変更（空で詰まらないよう）
- YQLに `userQuery()` が含まれて `query` が空の場合、オレンジの警告バナーを表示
- その状態では実行ボタンをグレーアウト・無効化してミスを防止

### 確認したこと

すべて意図通りに動いていること